### PR TITLE
Don't globally hide '.md a em'

### DIFF
--- a/theme/components/_global.scss
+++ b/theme/components/_global.scss
@@ -16,6 +16,3 @@ body{
 a[title="faded"]{
 	opacity: .4 !important;
 }
-.md a em {
-    display: none;
-}


### PR DESCRIPTION
I believe this is something we originally - in the before time - did for the sidebar (to provide text in place of logos when viewed without style) and then it sortof bled into the main rules by accident. I don't think it's appropriate to apply this rule across the board for all markdown areas in the base theme. It should instead be part of the sub-theme(s) and targeted more specifically (off the top of my head, the sidebar and possibly the self-text area for game threads).